### PR TITLE
Restart ecap container instructions fix for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ Start the infrastructure from the directory with the docker-compose.yml with the
  docker-compose up -d
 ```
 ### To audit the Salesforce or ChatGPT sessions through the squid-proxy, do the following:
-   1)  Indicate the Host <yourdockerhost> and the Port 3128 in your browser or Network System Settings.
-   2) The squid certificate is located in the datasunrise_ecap-1 docker container, in the '/home/datasunrise/ssl/'
- squidCA.pem directory.
+1) Indicate the Host <yourdockerhost> and the Port 3128 in your browser or Network System Settings.
+2) The squid certificate is located in the datasunrise_ecap-1 docker container, in the '/home/datasunrise/ssl/'
+squidCA.pem directory.
+3) Copy a file from a docker to a host directory <destiny> with the following command:
 
-   3) Copy a file from a docker to a host directory <destiny> with the following command:
-      ```bash
-      docker cp <project name>-datasunrise_ecap-1:/home/datasunrise/ssl/squidCA.pem <destiny>
-      ```
+```bash
+docker cp <project name>-datasunrise_ecap-1:/home/datasunrise/ssl/squidCA.pem <destiny>
+```
+
 **Note:** 
 After making changes to Generative AI settings (e.g., setting up the instance, audit rules, event tagging, or Dynamic Masking attributes), you need to restart the relevant container to apply them.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ After making changes to Generative AI settings (e.g., setting up the instance, a
 > Look for a container with **"ecap"** in its name and restart it:
 >
 > ```bash
-> docker container restart <container_name>
+> docker restart <container_name>
 > ```
 
 ### To configure the proxy-service, do the following:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ docker cp <project name>-datasunrise_ecap-1:/home/datasunrise/ssl/squidCA.pem <d
 **Note:** 
 After making changes to Generative AI settings (e.g., setting up the instance, audit rules, event tagging, or Dynamic Masking attributes), you need to restart the ecap container to apply them.
 
-> Look for a container with **"ecap"** in its name and restart it:
->
+> Look for a container with **"ecap"** in its name:
+> ```bash
+> sudo docker ps -a --filter "name=ecap" 
+> ```
+> and then restart it:
 > ```bash
 > docker restart <container_name>
 > ```

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker cp <project name>-datasunrise_ecap-1:/home/datasunrise/ssl/squidCA.pem <d
 ```
 
 **Note:** 
-After making changes to Generative AI settings (e.g., setting up the instance, audit rules, event tagging, or Dynamic Masking attributes), you need to restart the relevant container to apply them.
+After making changes to Generative AI settings (e.g., setting up the instance, audit rules, event tagging, or Dynamic Masking attributes), you need to restart the ecap container to apply them.
 
 > Look for a container with **"ecap"** in its name and restart it:
 >

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ Start the infrastructure from the directory with the docker-compose.yml with the
       ```bash
       docker cp <project name>-datasunrise_ecap-1:/home/datasunrise/ssl/squidCA.pem <destiny>
       ```
+> **Note:** 
+> After making changes to Generative AI settings (e.g., setting up the instance, audit rules, event tagging, or Dynamic Masking attributes), you need to restart the relevant container to apply them.
+>
+> Look for a container with **"ecap"** in its name and restart it:
+>
+> ```bash
+> docker container restart <container_name>
+> ```
+
 ### To configure the proxy-service, do the following:
 
 In DataSunrise go to the Configuration→Databases→Add Database. Input the following information to connect Redis service:

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Start the infrastructure from the directory with the docker-compose.yml with the
       ```bash
       docker cp <project name>-datasunrise_ecap-1:/home/datasunrise/ssl/squidCA.pem <destiny>
       ```
-> **Note:** 
-> After making changes to Generative AI settings (e.g., setting up the instance, audit rules, event tagging, or Dynamic Masking attributes), you need to restart the relevant container to apply them.
->
+**Note:** 
+After making changes to Generative AI settings (e.g., setting up the instance, audit rules, event tagging, or Dynamic Masking attributes), you need to restart the relevant container to apply them.
+
 > Look for a container with **"ecap"** in its name and restart it:
 >
 > ```bash


### PR DESCRIPTION
Absolutely — here it is, formatted properly for a PR description or commit message:

---

### Changes:

* **Added a new Note section** explaining that the `ecap` container must be restarted after Generative AI configuration changes.
* **Included commands to:**

  * **List containers** with `"ecap"` in the name:

    ```bash
    sudo docker ps -a --filter "name=ecap"
    ```
  * **Restart the container:**

    ```bash
    docker restart <container_name>
    ```
